### PR TITLE
Fix package imports and server paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 COPY ./src /code/app
 
 WORKDIR /code/app
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 COPY ./src /code/app
 
 WORKDIR /code/app
+USER non-root
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,6 +1,6 @@
 import requests
 import random
-from .constants import *
+from .constants import TOKEN_ENDPOINT, TRACK_URI_PREFIX, API_HOST, CANVAS_ROUTE
 from .protos.canvas_pb2 import EntityCanvazRequest, EntityCanvazResponse
 
 def get_access_token():  # sourcery skip: raise-specific-error

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,7 +1,7 @@
 import requests
 import random
-from constants import *
-from protos.canvas_pb2 import EntityCanvazRequest, EntityCanvazResponse
+from .constants import *
+from .protos.canvas_pb2 import EntityCanvazRequest, EntityCanvazResponse
 
 def get_access_token():  # sourcery skip: raise-specific-error
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -5,14 +5,15 @@ from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 import os
 import asyncio
-import canvas
-import canvTay
-from constants import TOKEN_RENEW_TIME
+from . import canvas
+from . import canvTay
+from .constants import TOKEN_RENEW_TIME
 
 app = FastAPI()
 
-templates = Jinja2Templates(directory="templates")
-app.mount("/static", StaticFiles(directory="static"), name="static")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
+app.mount("/static", StaticFiles(directory=os.path.join(BASE_DIR, "static")), name="static")
 
 ORIGIN = os.getenv('HOST_ORIGIN')
 origins = [


### PR DESCRIPTION
## Summary
- fix working directory for templates and static files
- update imports to be package-relative
- correct Docker startup command

## Testing
- `python -m py_compile src/main.py src/canvas.py src/canvTay.py`
- `uvicorn src.main:app --host 0.0.0.0 --port 8000` (fails without network)

------
https://chatgpt.com/codex/tasks/task_e_683f5e7c5ce48324a657c858d99e72f4

## Resumen por Sourcery

Corrige las importaciones de módulos y las rutas de archivos para asegurar la resolución correcta de los paquetes, ajusta la carga de plantillas y archivos estáticos para usar la ruta del directorio de origen, y actualiza el comando de inicio de Docker para lanzar el servidor correctamente.

Correcciones de errores:
- Corrige las sentencias de importación relativas al paquete para resolver los errores de búsqueda de módulos
- Corrige la resolución del directorio de plantillas y archivos estáticos utilizando la ruta base del módulo

Build:
- Corrige el CMD del Dockerfile para que uvicorn apunte a la ruta correcta del módulo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix module imports and file paths to ensure correct package resolution, adjust template and static file loading to use the source directory path, and update the Docker startup command to launch the server correctly.

Bug Fixes:
- Fix package-relative import statements to resolve module lookup errors
- Fix template and static file directory resolution by using the module's base path

Build:
- Correct Dockerfile CMD to point uvicorn at the correct module path

</details>