### PR TITLE
Fix typo in comment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ def get_token():
 async def startup_event(): 
     asyncio.get_event_loop().create_task(refresh_token())
 
-# Monstrar el index.html
+# Mostrar el index.html
 @app.get("/", response_class=HTMLResponse)
 async def read_item(request: Request):
     return templates.TemplateResponse("canvas.html", {"request": request})


### PR DESCRIPTION
## Summary
- fix a Spanish typo in `main.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6f1fe534832491b83e3613923cdc

## Resumen por Sourcery

Tareas de mantenimiento:
- Corregir errata en comentario en español de 'Monstrar' a 'Mostrar' en main.py

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Correct typo in Spanish comment from 'Monstrar' to 'Mostrar' in main.py

</details>