### PR TITLE
Fix CSV path in gallery script

### DIFF
--- a/src/static/scriptyy.js
+++ b/src/static/scriptyy.js
@@ -1,4 +1,4 @@
-var csvFile = "../static/canvastaynew.csv";
+var csvFile = "../static/canvtaynew.csv";
 var counter = 0;
 var loadingInProgress = false;
 var gallery = $('#gallery');


### PR DESCRIPTION
## Summary
- correct CSV filename in `scriptyy.js`
- verified other scripts reference existing CSV files

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f6f27ce1483248d3243115eb58623

## Resumen por Sourcery

Corrige la ruta del archivo CSV utilizada por el script de la galería y asegura que todos los demás scripts hagan referencia a archivos CSV válidos.

Correcciones de errores:
- Corrige el nombre del archivo CSV en `scriptyy.js` para que coincida con el archivo real.

Mejoras:
- Verifica que otros scripts de la galería hagan referencia a archivos CSV existentes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the CSV file path used by the gallery script and ensure all other scripts reference valid CSV files

Bug Fixes:
- Correct the CSV filename in scriptyy.js to match the actual file

Enhancements:
- Verify that other gallery scripts reference existing CSV files

</details>