### PR TITLE
Fix csv filename comment

### DIFF
--- a/src/canvTay.py
+++ b/src/canvTay.py
@@ -78,6 +78,6 @@ def credenciales():
 
     canvas_df = canvas_df.drop(['success', 'message'], axis=1)
 
-    # Guardar dataframe en csv, con el nombre canvtay.csv sin fecha
+    # Guardar dataframe en csv, con el nombre canvtaynew.csv sin fecha
     
     canvas_df.to_csv('canvtaynew.csv', index=False)


### PR DESCRIPTION
## Summary
- clarify the output CSV file name in canvTay

## Testing
- `python -m py_compile src/canvTay.py`
- `flake8 src/canvTay.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6f2b1f088324bd2eb3eeadcd63ea

## Resumen por Sourcery

Mejoras:
- Actualizar el comentario para que refleje que el nombre del archivo de salida CSV es 'canvtaynew.csv' en lugar de 'canvtay.csv'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update comment to reflect the CSV output filename as 'canvtaynew.csv' instead of 'canvtay.csv'

</details>