### PR TITLE
Add initial pytest suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ spotipy
 pandas
 numpy
 jinja2
+
+pytest

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -64,7 +64,7 @@ def test_get_canvas_for_track(monkeypatch):
         return Resp(serialized)
 
     monkeypatch.setattr(requests, "post", fake_post)
-    monkeypatch.setattr(random, "choice", lambda seq: seq[1])
+    monkeypatch.setattr(random, "choice", lambda seq: seq[1] if len(seq) > 1 else ValueError("Sequence must contain at least two elements"))
 
     url = canvas.get_canvas_for_track("token", "trackid")
     assert url == "http://c2"

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -17,6 +17,36 @@ def test_get_access_token(monkeypatch):
     token = canvas.get_access_token()
     assert token == "abc123"
 
+def test_get_access_token_requests_exception(monkeypatch):
+    def raise_exc(url):
+        raise requests.exceptions.RequestException("Network error")
+    monkeypatch.setattr(requests, "get", raise_exc)
+    token = canvas.get_access_token()
+    assert token is None
+
+def test_get_access_token_no_json(monkeypatch):
+    class Resp:
+        pass
+    monkeypatch.setattr(requests, "get", lambda url: Resp())
+    token = canvas.get_access_token()
+    assert token is None
+
+def test_get_access_token_invalid_json(monkeypatch):
+    class Resp:
+        def json(self):
+            raise ValueError("Invalid JSON")
+    monkeypatch.setattr(requests, "get", lambda url: Resp())
+    token = canvas.get_access_token()
+    assert token is None
+
+def test_get_access_token_missing_key(monkeypatch):
+    class Resp:
+        def json(self):
+            return {"notAccessToken": "nope"}
+    monkeypatch.setattr(requests, "get", lambda url: Resp())
+    token = canvas.get_access_token()
+    assert token is None
+
 
 def test_get_canvas_for_track(monkeypatch):
     response = EntityCanvazResponse()

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -3,9 +3,9 @@ import sys
 import requests
 import random
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-import canvas
+
+from src import canvas
 from protos.canvas_pb2 import EntityCanvazResponse
 
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import requests
+import random
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import canvas
+from protos.canvas_pb2 import EntityCanvazResponse
+
+
+def test_get_access_token(monkeypatch):
+    class Resp:
+        def json(self):
+            return {"accessToken": "abc123"}
+    monkeypatch.setattr(requests, "get", lambda url: Resp())
+    token = canvas.get_access_token()
+    assert token == "abc123"
+
+
+def test_get_canvas_for_track(monkeypatch):
+    response = EntityCanvazResponse()
+    c1 = response.canvases.add()
+    c1.url = "http://c1"
+    c2 = response.canvases.add()
+    c2.url = "http://c2"
+    serialized = response.SerializeToString()
+
+    class Resp:
+        def __init__(self, content):
+            self.content = content
+    
+    def fake_post(url, headers=None, data=None):
+        return Resp(serialized)
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[1])
+
+    url = canvas.get_canvas_for_track("token", "trackid")
+    assert url == "http://c2"


### PR DESCRIPTION
## Summary
- include pytest as a dependency
- add tests for canvas helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6f2e8ce08324aa5289bdba52c96d

## Resumen por Sourcery

Añade un conjunto de pruebas pytest inicial y pruebas para las funciones auxiliares de canvas.

Build:
- Añade pytest a las dependencias del proyecto en requirements.txt

Tests:
- Añade pruebas unitarias para canvas.get_access_token con requests.get simulado (mocked).
- Añade pruebas unitarias para canvas.get_canvas_for_track con requests.post simulado (mocked) y random.choice

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an initial pytest suite and tests for canvas helper functions.

Build:
- Add pytest to project dependencies in requirements.txt

Tests:
- Add unit tests for canvas.get_access_token with mocked requests.get
- Add unit tests for canvas.get_canvas_for_track with mocked requests.post and random.choice

</details>