### PR TITLE
Refresh Spotify access token using Client Credentials

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,13 +1,31 @@
+import base64
+import os
 import requests
 import random
 from .constants import TOKEN_ENDPOINT, TRACK_URI_PREFIX, API_HOST, CANVAS_ROUTE
 from .protos.canvas_pb2 import EntityCanvazRequest, EntityCanvazResponse
 
 def get_access_token():  # sourcery skip: raise-specific-error
+    """Retrieve a Spotify access token using the Client Credentials flow."""
+
+    client_id = os.getenv("SPOTIPY_CLIENT_ID")
+    client_secret = os.getenv("SPOTIPY_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        raise EnvironmentError("Missing Spotify client credentials")
+
+    credentials = f"{client_id}:{client_secret}".encode()
+    encoded_credentials = base64.b64encode(credentials).decode()
+
     try:
-        response = requests.get(TOKEN_ENDPOINT)
+        response = requests.post(
+            TOKEN_ENDPOINT,
+            headers={"Authorization": f"Basic {encoded_credentials}"},
+            data={"grant_type": "client_credentials"},
+        )
+        response.raise_for_status()
         data = response.json()
-        return data["accessToken"]
+        return data["access_token"], data["expires_in"]
     except Exception as e:
         raise Exception(e) from e
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,6 @@
 API_HOST = "https://gew1-spclient.spotify.com"
 CANVAS_ROUTE = "/canvaz-cache/v0/canvases"
-TOKEN_ENDPOINT = "https://open.spotify.com/get_access_token?reason=transport"
+TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token"
 TOKEN_RENEW_TIME = 900
 
 TRACK_URI_PREFIX = "spotify:track:"

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from . import canvas
 from . import canvTay
 from .constants import TOKEN_RENEW_TIME
 
+
 app = FastAPI()
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -57,11 +58,12 @@ async def refresh_token():
         print('INFO:     Getting a fresh Spotify access token')
 
         try:
-            access_token = canvas.get_access_token()
+            access_token, expires_in = canvas.get_access_token()
         except Exception as e:
             print(f'ERROR:   Failed to get a new access token: {e}')
+            expires_in = TOKEN_RENEW_TIME
 
-        await asyncio.sleep(TOKEN_RENEW_TIME)
+        await asyncio.sleep(expires_in)
         
 # Check with a method the token
 @app.get('/api/token')


### PR DESCRIPTION
## Summary
- use Spotify client credentials flow for token retrieval
- handle expires_in from token endpoint and sleep accordingly

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_683f7a7016548324b3fd15166123b901

## Resumen por Sourcery

Usa el flujo de OAuth de Credenciales de Cliente de Spotify para obtener tokens de acceso y programar dinámicamente la actualización de tokens basándose en el tiempo de expiración recibido.

Nuevas Funcionalidades:
- Implementa el flujo de credenciales de cliente leyendo SPOTIPY_CLIENT_ID/SECRET, codificándolos y enviando un POST al endpoint de tokens de Spotify para obtener access_token y expires_in.

Mejoras:
- Actualiza el bucle de actualización de tokens para que espere la duración real de expires_in y recurra a TOKEN_RENEW_TIME en caso de fallo.
- Cambia TOKEN_ENDPOINT a la URL oficial de la API de cuentas de Spotify y añade comprobaciones para credenciales de entorno faltantes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use Spotify Client Credentials OAuth flow to fetch access tokens and dynamically schedule token refreshes based on the received expiry time.

New Features:
- Implement client credentials flow by reading SPOTIPY_CLIENT_ID/SECRET, encoding them, and POSTing to the Spotify token endpoint to obtain access_token and expires_in.

Enhancements:
- Update the token refresh loop to sleep for the actual expires_in duration and fall back to TOKEN_RENEW_TIME on failure.
- Change TOKEN_ENDPOINT to the official Spotify accounts API URL and add checks for missing environment credentials.

</details>