### PR TITLE
Refresh token endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -65,11 +65,12 @@ async def refresh_token():
         
 # Check with a method the token
 @app.get('/api/token')
-def get_token():
-    # Get new token when executing this method
-    refresh_token()
-    # Show obtained token
-    return {'token': access_token}
+async def get_token():
+    """Fetch a fresh Spotify token and return it."""
+    global access_token
+    # Refresh token for this request
+    access_token = canvas.get_access_token()
+    return {"token": access_token}
 
 @app.on_event("startup")
 async def startup_event(): 


### PR DESCRIPTION
## Summary
- make `/api/token` asynchronous
- fetch a fresh token when hitting the route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7a78baec8324bfea8ee2217bd95e

## Resumen por Sourcery

Convierte la ruta /api/token a un controlador asíncrono que refresca y devuelve el token de acceso en cada solicitud.

Nuevas Funcionalidades:
- Hacer que el endpoint /api/token sea asíncrono
- Obtener un nuevo token de acceso en cada solicitud a /api/token

Mejoras:
- Reemplazar la llamada a `refresh_token()` con la invocación directa a `canvas.get_access_token()`
- Añadir un docstring al controlador del endpoint de token

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert the /api/token route to an async handler that refreshes and returns the access token on every request.

New Features:
- Make /api/token endpoint asynchronous
- Fetch a fresh access token on each /api/token request

Enhancements:
- Replace refresh_token() call with direct canvas.get_access_token() invocation
- Add docstring to the token endpoint handler

</details>