### PR TITLE
Refresh token endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -69,7 +69,7 @@ async def get_token():
     """Fetch a fresh Spotify token and return it."""
     global access_token
     # Refresh token for this request
-    access_token = canvas.get_access_token()
+    access_token = await asyncio.to_thread(canvas.get_access_token)
     return {"token": access_token}
 
 @app.on_event("startup")

--- a/src/main.py
+++ b/src/main.py
@@ -65,11 +65,12 @@ async def refresh_token():
         
 # Check with a method the token
 @app.get('/api/token')
-def get_token():
-    # Get new token when executing this method
-    refresh_token()
-    # Show obtained token
-    return {'token': access_token}
+async def get_token():
+    """Fetch a fresh Spotify token and return it."""
+    global access_token
+    # Refresh token for this request
+    access_token = canvas.get_access_token()
+    return {"token": access_token}
 
 @app.on_event("startup")
 async def startup_event(): 


### PR DESCRIPTION
## Summary
- make `/api/token` asynchronous
- fetch a fresh token when hitting the route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7a78baec8324bfea8ee2217bd95e

## Resumen por Sourcery

Mejoras:
- Convierte el endpoint /api/token a async y obtiene un nuevo token de acceso en cada solicitud

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Convert the /api/token endpoint to async and fetch a fresh access token on each request

</details>