### PR TITLE
Improve documentation for FastAPI usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SPOTIPY_CLIENT_ID=your_client_id
+SPOTIPY_CLIENT_SECRET=your_client_secret
+SPOTIPY_REDIRECT_URL=http://localhost/callback
+HOST_ORIGIN=http://localhost:8000
+# Opcional: credenciales para docker-compose
+SPOTIFY_USERNAME=spotify_username
+SPOTIFY_PASSWORD=spotify_password

--- a/README.md
+++ b/README.md
@@ -22,4 +22,30 @@ SPOTIPY_REDIRECT_URL
 ```
 
 Puedes crearlas en un archivo `.env` o exportarlas directamente en tu consola
-antes de ejecutar la aplicación.
+antes de ejecutar la aplicación. También es necesario definir `HOST_ORIGIN` con
+la URL desde la que se servirá la API.
+
+Puedes tomar como referencia el archivo `.env.example` incluido en el
+repositorio.
+
+## Ejecutar la aplicación
+
+Si trabajas localmente puedes iniciar el servidor con **uvicorn**:
+
+```bash
+uvicorn src.main:app --reload
+```
+
+Para levantar todo con Docker puedes usar:
+
+```bash
+docker-compose up --build
+```
+
+## Pruebas
+
+Las pruebas unitarias se ejecutan con **pytest**:
+
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- document environment variables and add `.env.example`
- explain how to run the FastAPI server
- note how to run tests with `pytest`

## Testing
- `pytest -q` *(fails: No module named 'protos.canvas_pb2')*

------
https://chatgpt.com/codex/tasks/task_e_688c4a6cd5408324bd83606778e417cd

## Resumen por Sourcery

Mejorar la documentación del proyecto con ejemplos de variables de entorno, comandos de inicio del servidor e instrucciones de prueba para el uso de FastAPI.

Documentación:
- Añadir el archivo .env.example mostrando las variables de entorno requeridas
- Documentar la necesidad de HOST_ORIGIN y hacer referencia a .env.example
- Proporcionar instrucciones para ejecutar la aplicación FastAPI localmente con uvicorn y a través de Docker Compose
- Incluir comandos de pytest para ejecutar pruebas unitarias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance project documentation with environment variable examples, server startup commands, and testing instructions for FastAPI usage

Documentation:
- Add .env.example file showcasing required environment variables
- Document the need for HOST_ORIGIN and reference .env.example
- Provide instructions to run the FastAPI app locally with uvicorn and via Docker Compose
- Include pytest commands for running unit tests

</details>